### PR TITLE
Update for compatibility with v2 of hipchat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ Go to the `hooks` directory in a bare repository you want to setup the hooks for
 
 You can lookup the HipChat room id from the [rooms/list](https://www.hipchat.com/docs/api/method/rooms/list) API or use the HipChat room name (remember to urlencode it)
 
+Keep in mind that a v1 API token is different from a v2 token.
+
 ```sh
 #!/bin/sh
 
-HIPCHAT_SCRIPT="/path/to/hipchat_room_message"
+HIPCHAT_SCRIPT="/path/to/hipchat_room_message -v2"
 HIPCHAT_ROOM="HipChat room name or room_id"
 HIPCHAT_TOKEN="1234567890"
 HIPCHAT_FROM="GIT"

--- a/hipchat-post-receive
+++ b/hipchat-post-receive
@@ -70,7 +70,7 @@ else
   then
     LOG=`echo -e "$LOG" | sed "s/\([A-Z]\{2,\}\-[0-9]\{1,\}\)/<a href=\"http:\/\/$JIRA\/browse\/\1\">\1<\/a>/g"`
   fi
-  MSG="$TITLE\n$LOG"
+  MSG="$TITLE</br>$LOG"
 fi
 
 # Send it to HipChat


### PR DESCRIPTION
Hipchat has switched to v2 and there are some changes that make the existing instructions not work out-of-the-box...

First of all I get errors about an invalid character on the newline when I try to send a message, so I replaced that with an HTML line break since we're sending HTML already.

Secondly, I could only figure out how to create a v2 access token on the hipchat website. There might still be a way to get a v1 token but I couldn't find it so I updated the README to include the -v2 command line switch.